### PR TITLE
Added `onabort` to XMLHttpRequest event listeners

### DIFF
--- a/src/request.js
+++ b/src/request.js
@@ -19,7 +19,7 @@ export default function(url, callback) {
       && /^(http(s)?:)?\/\//.test(url)) xhr = new XDomainRequest;
 
   "onload" in xhr
-      ? xhr.onload = xhr.onerror = xhr.ontimeout = respond
+      ? xhr.onload = xhr.onerror = xhr.ontimeout = xhr.onabort = respond
       : xhr.onreadystatechange = function(o) { xhr.readyState > 3 && respond(o); };
 
   function respond(o) {


### PR DESCRIPTION
So, I had this code which failed to indicate completion when an `xhr` request was aborted.  Ergo, I had to add `onabort`.  I couldn't see a super-tidy way of integrating it, so I just left it to default as an error, which can (again by default) be detected by checking `error.type === 'abort'`

Simplified code sample, which is working great now.

```
function setupCompletionHandler(selection) {
    counter = selection.size();
}

function onTileComplete() {
    if (--counter === 0)
        self.emit('complete');
}

image.exit()
    .each(function(d) { this._xhr && this._xhr.abort(); });

image.enter()
    .call(setupCompletionHandler)
    .append("svg")
    .each(function(d) {
        this._xhr = d3.request(url)
            .get(function(error, data) {
                onTileComplete();
                if (error)
                    if (error.type !== 'abort')
                        throw error;
                process(data);
            });
    });
```

If there's a better way to do this, I'm all ears.  I could see it being possible with d3-queue, but ideally a simple **completion event** would be delightful.  The solution I arrived at was found at SO.